### PR TITLE
Add multiple support for ordering by multiple attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added: it's possible to query using "or" method
 * Added: it's possible merge multiple queries
 * Added: class methods can be used as a scope (like in ActiveRecord)
+* Added: it's possible to order by multiple atttributes
 
 ## [0.1.0] - 2019-04-25
 

--- a/lib/active_graphql/model/relation_proxy.rb
+++ b/lib/active_graphql/model/relation_proxy.rb
@@ -169,24 +169,35 @@ module ActiveGraphql
         formatted_action(raw.meta(paginated: true)).to_graphql
       end
 
-      def order(order_params)
-        if order_params.is_a?(Hash)
-          order_by = order_params.keys.first
-          direction = order_params.values.first
-        else
-          order_by = order_params
-          direction = :asc
+      def order(*order_params)
+        order_params_attributes = order_params.flat_map do |order_param|
+          ordering_attributes(order_param)
         end
+        order_params_attributes.compact!
 
-        return chain(order_attributes: {}) if order_by.to_s.empty?
+        return chain(order_attributes: {}) if order_params_attributes.to_s.empty?
 
         chain(
-          order_attributes: {
-            by: order_by.to_s.upcase,
-            direction: direction.to_s.upcase,
-            __keyword_attributes: %i[by direction]
-          }
+          order_attributes: order_params_attributes
         )
+      end
+
+      def ordering_attributes(order_param)
+        if order_param.is_a?(Hash)
+          order_param.map { |param, direction| order_param_attributes(param, direction) }
+        else
+          order_param_attributes(order_param, :asc)
+        end
+      end
+
+      def order_param_attributes(order_by, direction)
+        return if order_by.blank?
+
+        {
+          by: order_by.to_s.upcase,
+          direction: direction.to_s.upcase,
+          __keyword_attributes: %i[by direction]
+        }
       end
 
       def empty?

--- a/spec/lib/active_graphql/model/relation_proxy_spec.rb
+++ b/spec/lib/active_graphql/model/relation_proxy_spec.rb
@@ -186,6 +186,34 @@ module ActiveGraphql::Model
           GRAPHQL
         end
       end
+
+      context 'when order by field is nil' do
+        subject(:order) { relation_proxy.order(nil => :asc) }
+
+        it 'builds graphql with null order by attribute' do
+          expect(order.to_graphql).to eq <<~GRAPHQL
+            query {
+              users(order: [{ by: null, direction: ASC }]) {
+                edges { node { id, firstName } }, pageInfo { hasNextPage }
+              }
+            }
+          GRAPHQL
+        end
+      end
+
+      context 'when order method is chained with another order' do
+        subject(:order) { relation_proxy.order(:something1).order(something2: :desc) }
+
+        it 'builds graphql with combined ordering attributes' do
+          expect(order.to_graphql).to eq <<~GRAPHQL
+            query {
+              users(order: [{ by: SOMETHING1, direction: ASC }, { by: SOMETHING2, direction: DESC }]) {
+                edges { node { id, firstName } }, pageInfo { hasNextPage }
+              }
+            }
+          GRAPHQL
+        end
+      end
     end
 
     describe '#page' do

--- a/spec/lib/active_graphql/model/relation_proxy_spec.rb
+++ b/spec/lib/active_graphql/model/relation_proxy_spec.rb
@@ -137,7 +137,7 @@ module ActiveGraphql::Model
         it 'builds correct graphql' do
           expect(order.to_graphql).to eq <<~GRAPHQL
             query {
-              users(order: { by: SOMETHING, direction: DESC }) {
+              users(order: [{ by: SOMETHING, direction: DESC }]) {
                 edges { node { id, firstName } }, pageInfo { hasNextPage }
               }
             }
@@ -151,7 +151,35 @@ module ActiveGraphql::Model
         it 'builds graphql with ASC order direction' do
           expect(order.to_graphql).to eq <<~GRAPHQL
             query {
-              users(order: { by: SOMETHING, direction: ASC }) {
+              users(order: [{ by: SOMETHING, direction: ASC }]) {
+                edges { node { id, firstName } }, pageInfo { hasNextPage }
+              }
+            }
+          GRAPHQL
+        end
+      end
+
+      context 'when multiple fields are given' do
+        subject(:order) { relation_proxy.order(:something, something1: :asc, something2: :desc) }
+
+        it 'builds graphql with ASC order direction' do
+          expect(order.to_graphql).to eq <<~GRAPHQL
+            query {
+              users(order: [{ by: SOMETHING, direction: ASC }, { by: SOMETHING1, direction: ASC }, { by: SOMETHING2, direction: DESC }]) {
+                edges { node { id, firstName } }, pageInfo { hasNextPage }
+              }
+            }
+          GRAPHQL
+        end
+      end
+
+      context 'when fields are nil' do
+        subject(:order) { relation_proxy.order(nil) }
+
+        it 'builds graphql without order attribute' do
+          expect(order.to_graphql).to eq <<~GRAPHQL
+            query {
+              users {
                 edges { node { id, firstName } }, pageInfo { hasNextPage }
               }
             }

--- a/spec/support/app/dummy_schema.rb
+++ b/spec/support/app/dummy_schema.rb
@@ -3,6 +3,7 @@
 require 'graphql'
 require 'graphql_rails'
 require 'active_record'
+require_relative 'models/dummy_user'
 
 class DummySchema < GraphQL::Schema
   module PlainCursorEncoder


### PR DESCRIPTION
Since now order by one attribute was supported.

This PR adds ability to sort by multiple attributes, like
```
scope.order(:attr1, attr2)
or 
scope.order(attr1: :asc, attr2: :desc)
```