### PR TITLE
Add ability to select graphql attributes on model

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -322,7 +322,7 @@ Example: `user(id: ID!)`
 
 In order to make Model#all and Model#find_each work, server must have resource in plural form and also response should be paginated.
 
-Example: 
+Example:
 ```
 users(first: Integer, last: Integer, before: String, after: String) {
   edges {
@@ -337,7 +337,7 @@ users(first: Integer, last: Integer, before: String, after: String) {
 
 In order to make Model#where and Model#find_by work, server must have resource in plural form with `filter: SomeFilterInput` argument. Also resource must match requirements for Model#all too (see previous section)
 
-Example: 
+Example:
 ```
 type UsersFilterInput {
   firstName: String!
@@ -357,7 +357,7 @@ users(filter: UserFilterInput) {
 
 In order to make Model#or resouce must match requirements for `Model#where` method. Also `filter` input must have `or` argument
 
-Example: 
+Example:
 ```
 type UsersFilterInput {
   or: UsersOrFilterInput
@@ -383,7 +383,7 @@ users(filter: UserFilterInput) {
 
 In order to make Model#where and Model#find_by work, server must have resource in plural form. This resource must have `total:Integer` **output** field:
 
-Example: 
+Example:
 ```
 users() {
   total

--- a/lib/active_graphql/model.rb
+++ b/lib/active_graphql/model.rb
@@ -106,7 +106,7 @@ module ActiveGraphql
     end
 
     class_methods do # rubocop:disable Metrics/BlockLength
-      delegate :first, :last, :limit, :count, :where, :find_each, :find, to: :all
+      delegate :first, :last, :limit, :count, :where, :select, :select_attributes, :find_each, :find, to: :all
 
       def inherited(sublass)
         sublass.instance_variable_set(:@active_graphql, active_graphql.dup)
@@ -153,7 +153,7 @@ module ActiveGraphql
 
         raw_action = \
           yield(api)
-          .output(*active_graphql.attributes_graphql_output)
+          .output(*select_attributes)
           .meta(primary_key: active_graphql.primary_key)
 
         formatter.call(raw_action).response

--- a/lib/active_graphql/model/relation_proxy.rb
+++ b/lib/active_graphql/model/relation_proxy.rb
@@ -13,17 +13,18 @@ module ActiveGraphql
 
       include Enumerable
 
-      attr_reader :where_attributes
+      attr_reader :where_attributes, :output_values
 
       delegate :each, :map, to: :to_a
 
-      def initialize(model, limit_number: nil, where_attributes: {}, offset_number: nil, meta_attributes: {}, order_attributes: [])
+      def initialize(model, limit_number: nil, where_attributes: {}, offset_number: nil, meta_attributes: {}, order_attributes: [], output_values: [])
         @model = model
         @limit_number = limit_number
         @where_attributes = where_attributes
         @offset_number = offset_number
         @meta_attributes = meta_attributes
         @order_attributes = order_attributes
+        @output_values = output_values
       end
 
       def all
@@ -40,6 +41,25 @@ module ActiveGraphql
 
       def where(new_where_attributes)
         chain(where_attributes: where_attributes.deep_merge(new_where_attributes.symbolize_keys))
+      end
+
+      def select(*array_outputs, **hash_outputs)
+        full_array_outputs = (output_values + array_outputs).uniq
+        reselect(*full_array_outputs, **hash_outputs)
+      end
+      alias output select
+
+      def reselect(*array_outputs, **hash_outputs)
+        outputs = join_array_and_hash(*array_outputs, **hash_outputs)
+        chain(output_values: outputs)
+      end
+
+      def select_attributes
+        output_values.present? ? (output_values & config.attributes_graphql_output) : config.attributes_graphql_output
+      end
+
+      def join_array_and_hash(*array, **hash)
+        array + hash.map { |k, v| { k => v } }
       end
 
       def merge(other_query)
@@ -92,7 +112,7 @@ module ActiveGraphql
         action = formatted_action(
           graphql_client
             .query(resource_name)
-            .select(*config.attributes_graphql_output)
+            .select(*select_attributes)
             .where(config.primary_key => id)
         )
 
@@ -240,7 +260,7 @@ module ActiveGraphql
           graphql_client
             .query(resource_plural_name)
             .meta(meta_attributes)
-            .select(config.attributes_graphql_output)
+            .select(select_attributes)
             .where(graphql_params)
         end
       end
@@ -276,7 +296,8 @@ module ActiveGraphql
         where_attributes: send(:where_attributes),
         meta_attributes: send(:meta_attributes),
         offset_number: send(:offset_number),
-        order_attributes: send(:order_attributes)
+        order_attributes: send(:order_attributes),
+        output_values: send(:output_values)
       )
         self.class.new(
           model,
@@ -284,7 +305,8 @@ module ActiveGraphql
           where_attributes: where_attributes,
           meta_attributes: meta_attributes,
           offset_number: offset_number,
-          order_attributes: order_attributes
+          order_attributes: order_attributes,
+          output_values: output_values
         )
       end
 

--- a/lib/active_graphql/model/relation_proxy.rb
+++ b/lib/active_graphql/model/relation_proxy.rb
@@ -47,7 +47,6 @@ module ActiveGraphql
         full_array_outputs = (output_values + array_outputs).uniq
         reselect(*full_array_outputs, **hash_outputs)
       end
-      alias output select
 
       def reselect(*array_outputs, **hash_outputs)
         outputs = join_array_and_hash(*array_outputs, **hash_outputs)
@@ -55,11 +54,7 @@ module ActiveGraphql
       end
 
       def select_attributes
-        output_values.present? ? (output_values & config.attributes_graphql_output) : config.attributes_graphql_output
-      end
-
-      def join_array_and_hash(*array, **hash)
-        array + hash.map { |k, v| { k => v } }
+        output_values.presence || config.attributes_graphql_output
       end
 
       def merge(other_query)
@@ -316,6 +311,10 @@ module ActiveGraphql
 
       def config
         model.active_graphql
+      end
+
+      def join_array_and_hash(*array, **hash)
+        array + hash.map { |k, v| { k => v } }
       end
     end
   end

--- a/spec/lib/active_graphql/model/relation_proxy_spec.rb
+++ b/spec/lib/active_graphql/model/relation_proxy_spec.rb
@@ -142,6 +142,36 @@ module ActiveGraphql::Model
           }
         GRAPHQL
       end
+
+      context 'with a little bit complex query' do
+        subject(:select) { relation_proxy.select(:first_name, location: :city, name: :full_name) }
+
+        let(:model) do
+          Class.new do
+            include ActiveGraphql::Model
+
+            active_graphql do |c|
+              c.url 'http://example.com/graphql'
+              c.attributes :id, :first_name, location: %i[street city], name: :full_name
+              c.primary_key :parent_id
+            end
+
+            def self.name
+              'User'
+            end
+          end
+        end
+
+        it 'builds correct graphql' do
+          expect(select.to_graphql).to eq <<~GRAPHQL
+            query {
+              users {
+                edges { node { firstName, location { city }, name { fullName } } }, pageInfo { hasNextPage }
+              }
+            }
+          GRAPHQL
+        end
+      end
     end
 
     describe '#order' do

--- a/spec/lib/active_graphql/model/relation_proxy_spec.rb
+++ b/spec/lib/active_graphql/model/relation_proxy_spec.rb
@@ -153,7 +153,6 @@ module ActiveGraphql::Model
             active_graphql do |c|
               c.url 'http://example.com/graphql'
               c.attributes :id, :first_name, location: %i[street city], name: :full_name
-              c.primary_key :parent_id
             end
 
             def self.name

--- a/spec/lib/active_graphql/model/relation_proxy_spec.rb
+++ b/spec/lib/active_graphql/model/relation_proxy_spec.rb
@@ -130,6 +130,20 @@ module ActiveGraphql::Model
       end
     end
 
+    describe '#select' do
+      subject(:select) { relation_proxy.select(:first_name) }
+
+      it 'builds correct graphql' do
+        expect(select.to_graphql).to eq <<~GRAPHQL
+          query {
+            users {
+              edges { node { firstName } }, pageInfo { hasNextPage }
+            }
+          }
+        GRAPHQL
+      end
+    end
+
     describe '#order' do
       subject(:order) { relation_proxy.order(something: :desc) }
 


### PR DESCRIPTION
In real life there are situations when only certain attributes of model which includes active_graphql must be selected. 
This PR adds `#select` method for active_record model and now we can write queries for models which look like this: 

```ruby
class User
  include ActiveGraphql::Model

  active_graphql do |c|
    c.resource_name :user
    c.attributes :id, :first_name
  end

  def self.user_names
    select(:first_name)
  end
end

User.user_names.to_graphql # => 
<<~GRAPHQL
  query {
    users {
      edges { node { firstName } }, pageInfo { hasNextPage }
    }
  }
GRAPHQL
```