### PR TITLE
Fix graphql errors handling with activemodel

### DIFF
--- a/lib/active_graphql/client/actions/mutation_action.rb
+++ b/lib/active_graphql/client/actions/mutation_action.rb
@@ -21,7 +21,7 @@ module ActiveGraphql
           response = where(inputs).response
           return response.result if response.success?
 
-          raise UnsuccessfullRequestError, response.errors.first
+          raise UnsuccessfullRequestError, response.error_messages.first
         end
       end
     end

--- a/lib/active_graphql/client/response.rb
+++ b/lib/active_graphql/client/response.rb
@@ -20,7 +20,7 @@ module ActiveGraphql
       end
 
       def result!
-        raise ResponseError, errors.first if errors.any?
+        raise ResponseError, error_messages.first if error_messages.any?
 
         graphql_object
       end
@@ -30,9 +30,13 @@ module ActiveGraphql
       end
 
       def errors
-        return [] if graphql_error.nil?
+        graphql_error&.errors
+      end
 
-        graphql_error.errors.values.flatten
+      def error_messages
+        return [] if errors.nil?
+
+        errors.values.flatten
       end
 
       private

--- a/lib/active_graphql/model.rb
+++ b/lib/active_graphql/model.rb
@@ -99,6 +99,14 @@ module ActiveGraphql
         graphql_errors.each { |error| errors.add('graphql', error) }
       end
 
+      def read_attribute_for_validation(key)
+        if key == 'graphql'
+          key
+        else
+          super
+        end
+      end
+
       def primary_key
         self.class.active_graphql.primary_key
       end

--- a/lib/active_graphql/model.rb
+++ b/lib/active_graphql/model.rb
@@ -41,7 +41,7 @@ module ActiveGraphql
         all_params = { primary_key => primary_key_value }.merge(params)
         response = exec_graphql { |api| api.mutation(action_name.to_s).input(all_params) }
         self.attributes = response.result.to_h
-        self.graphql_errors = response.errors
+        self.graphql_errors = response.error_messages
         valid?
       end
 
@@ -100,11 +100,7 @@ module ActiveGraphql
       end
 
       def read_attribute_for_validation(key)
-        if key == 'graphql'
-          key
-        else
-          super
-        end
+        key == 'graphql' ? key : super
       end
 
       def primary_key
@@ -141,7 +137,7 @@ module ActiveGraphql
         response = exec_graphql { |api| api.mutation(action_name).input(params) }
 
         new(response.result.to_h).tap do |record|
-          record.graphql_errors = response.errors unless response.success?
+          record.graphql_errors = response.error_messages unless response.success?
         end
       end
 

--- a/spec/lib/active_graphql/model_spec.rb
+++ b/spec/lib/active_graphql/model_spec.rb
@@ -252,5 +252,60 @@ module ActiveGraphql
         end
       end
     end
+
+    describe '#errors' do
+      describe '#add' do
+        let(:record) { model.new(id: 1) }
+
+        before do
+          record.errors.add(error_attribute, error_message)
+        end
+
+        shared_examples 'can handle stringy errors' do
+          it 'contains defined error' do
+            expect(record.errors[error_attribute]).to include(error_message)
+          end
+        end
+
+        shared_examples 'can handle symbolic errors' do
+          it 'contains builds activemodel error', :aggregate_failures do
+            expect(record.errors[error_attribute].first).to include('activemodel.errors')
+            expect(record.errors[error_attribute].first).to include(error_message.to_s)
+          end
+        end
+
+        context 'when error is from graphql' do
+          let(:error_attribute) { 'graphql' }
+
+          context 'when error message is string value' do
+            let(:error_message) { 'stringy error message' }
+
+            include_examples 'can handle stringy errors'
+          end
+
+          context 'when error message is symbol' do
+            let(:error_message) { :symbolic_error }
+
+            include_examples 'can handle symbolic errors'
+          end
+        end
+
+        context 'when error is from another attribute' do
+          let(:error_attribute) { 'first_name' }
+
+          context 'when error message is string value' do
+            let(:error_message) { 'stringy error message' }
+
+            include_examples 'can handle stringy errors'
+          end
+
+          context 'when error message is symbol' do
+            let(:error_message) { :symbolic_error }
+
+            include_examples 'can handle symbolic errors'
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
According `ActiveModel::Validations` everytime when we want get attribute for validation that attribute is called from `#read_attribute_for_validation` method to check it's value. 
The problem is that we are using keyword `'graphql'` as an attribute name for all errors related with graphql queries. 

This fix escapes `graphql` errors for this kind of errors handling flow.