### PR TITLE
Add save method to active graphql model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_graphql (0.2.2)
+    active_graphql (0.2.3)
       activemodel (>= 3.0.0)
       activesupport (>= 4.0.0)
       graphlient (~> 0.3)

--- a/lib/active_graphql/model.rb
+++ b/lib/active_graphql/model.rb
@@ -74,6 +74,22 @@ module ActiveGraphql
         self
       end
 
+      def save
+        if primary_key_value.present?
+          update(attributes.except(primary_key))
+        else
+          self.class.create(attributes)
+        end
+      end
+
+      def save!
+        if primary_key_value.present?
+          update!(attributes.reject { |attr, _| attr == primary_key })
+        else
+          self.class.create!(attributes)
+        end
+      end
+
       protected
 
       def exec_graphql(*args, &block)

--- a/lib/active_graphql/version.rb
+++ b/lib/active_graphql/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveGraphql
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end

--- a/spec/lib/active_graphql/model_spec.rb
+++ b/spec/lib/active_graphql/model_spec.rb
@@ -370,5 +370,69 @@ module ActiveGraphql
         end
       end
     end
+
+    describe '#save' do
+      subject(:save) { record.save }
+
+      let(:record) { model.new(params) }
+
+      context 'when model attributes contains primary key attribute' do
+        let(:params) { { id: 1, first_name: 'John Pelek' } }
+
+        before do
+          allow(record).to receive(:update)
+        end
+
+        it 'performs update mutation' do
+          save
+          expect(record).to have_received(:update).with(first_name: 'John Pelek')
+        end
+      end
+
+      context 'when model attributes does not include primary key attribute' do
+        let(:params) { { first_name: 'John Pelek' } }
+
+        before do
+          allow(record.class).to receive(:create)
+        end
+
+        it 'performs create mutation' do
+          save
+          expect(record.class).to have_received(:create).with(params)
+        end
+      end
+    end
+
+    describe '#save!' do
+      subject(:save!) { record.save! }
+
+      let(:record) { model.new(params) }
+
+      context 'when model attributes contains primary key attribute' do
+        let(:params) { { id: 1, first_name: 'John Pelek' } }
+
+        before do
+          allow(record).to receive(:update!)
+        end
+
+        it 'performs update mutation' do
+          save!
+          expect(record).to have_received(:update!).with(first_name: 'John Pelek')
+        end
+      end
+
+      context 'when model attributes does not include primary key attribute' do
+        let(:params) { { first_name: 'John Pelek' } }
+
+        before do
+          allow(record.class).to receive(:create!)
+        end
+
+        it 'performs create mutation' do
+          save!
+          expect(record.class).to have_received(:create!).with(params)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
There are times when we want to only build or modify active graphql model and save it later.

This PR introduces #save and #save! methods which does mutations accordingly via create or update mutation.  